### PR TITLE
Add ollama_chat module for Ollama API interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Uses [Semantic Versioning](https://semver.org/). Always [keep a change
 log](https://keepachangelog.com/en/1.0.0/).
 
+## [0.23.8] - 2025-05-31
+### Added
+- Predicate `ollama_chat(+Messages:list(dict), -Message:dict, +Options:list)`
+
 ## [0.23.7] - 2025-05-11
 ### Added
 - Predicate `directory_entry(+Directory, ?Entry)//`, module `dcg_files`

--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(canny_tudor).
-version('0.23.7').
+version('0.23.8').
 title('Canny bag o'' Tudor').
 
 author('Roy Ratcliffe', 'roy@ratcliffe.me').

--- a/prolog/ollama/chat.pl
+++ b/prolog/ollama/chat.pl
@@ -2,6 +2,28 @@
     Author:  Roy Ratcliffe
     Created: May 31 2025
     Purpose: Ollama Chat
+
+Copyright (c) 2025, Roy Ratcliffe, Northumberland, United Kingdom
+
+Permission is hereby granted, free of charge,  to any person obtaining a
+copy  of  this  software  and    associated   documentation  files  (the
+"Software"), to deal in  the   Software  without  restriction, including
+without limitation the rights to  use,   copy,  modify,  merge, publish,
+distribute, sub-license, and/or sell copies  of   the  Software,  and to
+permit persons to whom the Software is   furnished  to do so, subject to
+the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT  WARRANTY OF ANY KIND, EXPRESS
+OR  IMPLIED,  INCLUDING  BUT  NOT   LIMITED    TO   THE   WARRANTIES  OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR   PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS  OR   COPYRIGHT  HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY,  WHETHER   IN  AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM,  OUT  OF   OR  IN  CONNECTION  WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 */
 
 :- module(ollama_chat,

--- a/prolog/ollama/chat.pl
+++ b/prolog/ollama/chat.pl
@@ -1,0 +1,64 @@
+/*  File:    ollama/chat.pl
+    Author:  Roy Ratcliffe
+    Created: May 31 2025
+    Purpose: Ollama Chat
+*/
+
+:- module(ollama_chat,
+          [ ollama_chat/3 % +Messages:list, -Message:dict, +Options:list
+          ]).
+:- use_module(library(http/http_open), [http_open/3]).
+:- use_module(library(http/http_client), [http_read_data/3]).
+:- use_module(library(settings), [setting/4, setting/2]).
+:- use_module(library(option), [option/3, select_option/4]).
+
+:- ensure_loaded(library(http/http_json)).
+
+:- setting(ollama_url, atom, env('OLLAMA_URL', 'http://localhost:11434/api/chat'),
+           'URL of Ollama API.').
+:- setting(ollama_model, string, env('OLLAMA_MODEL', "nemotron-mini"),
+           'Ollama model to use.').
+
+/** <module> Ollama Chat
+
+*/
+
+:- multifile http_json:json_type/1.
+
+http_json:json_type(application/'x-ndjson').
+
+%!  ollama_chat(+Messages:list(dict), -Message:dict, +Options:list) is
+%!              nondet.
+
+ollama_chat(Messages, Message, Options) :-
+    option(stream(Stream), Options, true),
+    setting(ollama_model, DefaultModel),
+    option(model(Model), Options, DefaultModel),
+    option(reply(Reply), Options, Reply),
+    setting(ollama_url, DefaultURL),
+    option(url(URL), Options, DefaultURL),
+    chat(URL, _{stream:Stream,
+                model:Model,
+                messages:Messages}, Reply, Options),
+    Message = Reply.message.
+
+chat(URL, Dict, Reply, Options) :-
+    http_open(URL, In, [post(json(Dict)), headers(Headers)|Options]),
+    call_cleanup(read_dict(In, Reply, Headers), close(In)).
+
+read_dict(In, Dict, Options) :-
+    read_data(In, Dict, [json_object(dict)|Options]),
+    (   get_dict(done, Dict, false)
+    ->  true
+    ;   !
+    ).
+
+read_data(In, NotEndOfFileData, Options) :-
+    select_option(end_of_file(EndOfFile), Options, Options_, end_of_file),
+    repeat,
+    (   http_read_data([input(In)], Data, [end_of_file(EndOfFile)|Options_]),
+        Data \== EndOfFile
+    ->  NotEndOfFileData = Data
+    ;   !,
+        fail
+    ).


### PR DESCRIPTION
Introduce a new module for interacting with the Ollama chat API, enhance documentation with usage examples for both streaming and non-streaming modes, and update copyright and licensing information.